### PR TITLE
Add configurable mod start delay

### DIFF
--- a/mod/_WorldGenStateCapture/Config.cs
+++ b/mod/_WorldGenStateCapture/Config.cs
@@ -36,6 +36,11 @@ namespace _WorldGenStateCapture
         [JsonProperty]
         public bool AcceptRequestedSeeds { get; set; } = true;
 
+		[Option("STRINGS.WORLDPARSERMODCONFIG.MODSTARTDELAY.NAME", "STRINGS.WORLDPARSERMODCONFIG.MODSTARTDELAY.DESC")]
+		[JsonProperty]
+		[Limit(5, 100)] // Allow up to 100 seconds of delay, with a minimum of 5 to prevent soft-locking (but configurable in JSON directly to entirely skip the delay for power users)
+		public int ModStartDelay { get; set; } = 10;
+
         public enum ClusterSelection_Base
 		{
 			[Option("STRINGS.WORLDS.BADLANDS.NAME")]

--- a/mod/_WorldGenStateCapture/ImageSave.cs
+++ b/mod/_WorldGenStateCapture/ImageSave.cs
@@ -1,0 +1,315 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.IO;
+using rail;
+
+// To ensure flexibility, do not directly use any functions from Oxygen Not Included
+namespace _WorldGenStateCapture
+{
+    class ImageSave
+    {
+        public static unsafe void Save2dUint8ArrayAsPNG(string filePath, int width, int height, ushort* array)
+        {
+
+            using (Bitmap bitmap = new Bitmap(width, height, PixelFormat.Format8bppIndexed))
+            {
+                // Set grayscale palette (Required for Format8bppIndexed)
+                ColorPalette palette = bitmap.Palette;
+                for (int i = 0; i < 256; i++)
+                {
+                    palette.Entries[i] = Color.FromArgb(i, i, i);
+                }
+                bitmap.Palette = palette;
+
+                BitmapData data = bitmap.LockBits(
+                    new Rectangle(0, 0, width, height),
+                    ImageLockMode.WriteOnly,
+                    PixelFormat.Format8bppIndexed);
+
+                byte* dst = (byte*)data.Scan0;
+                int stride = data.Stride; // May be larger than width
+                ushort* src = array;
+
+                for (int y = 0; y < height; y++)
+                {
+                    for (int x = 0; x < width; x++)
+                    {
+                        dst[y * stride + x] = (byte)(src[y * width + x] & 0xFF); // Convert ushort -> byte
+                    }
+                }
+
+                bitmap.UnlockBits(data);
+
+                try
+                {
+                    bitmap.Save(filePath, ImageFormat.Png);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error saving file: {ex.Message}");
+                }
+            }
+        }
+        public static unsafe void Save2dFloat32ArrayAsPNG8(string filePath, int width, int height, float* array, List<System.Tuple<double, double, double>> bins, double offset)
+        {
+            using (Bitmap bitmap = new Bitmap(width, height, PixelFormat.Format8bppIndexed))
+            {
+                // Set grayscale palette (Required for Format8bppIndexed)
+                ColorPalette palette = bitmap.Palette;
+                for (int i = 0; i < 256; i++)
+                {
+                    palette.Entries[i] = Color.FromArgb(i, i, i);
+                }
+                bitmap.Palette = palette;
+
+                BitmapData data = bitmap.LockBits(
+                    new Rectangle(0, 0, width, height),
+                    ImageLockMode.WriteOnly,
+                    PixelFormat.Format8bppIndexed);
+
+                byte* dst = (byte*)data.Scan0;
+                int stride = data.Stride; // May be larger than width
+                float* src = array;
+
+                for (int y = 0; y < height; y++)
+                {
+                    for (int x = 0; x < width; x++)
+                    {
+                        float rawValue = array[y * width + x];
+                        float adjustedValue = rawValue + (float)offset;
+                        byte binIndex = (byte)GetBinIndex(adjustedValue, bins);
+                        dst[y * stride + x] = binIndex;
+                    }
+                }
+
+                bitmap.UnlockBits(data);
+
+                try
+                {
+                    bitmap.Save(filePath, ImageFormat.Png);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error saving file: {ex.Message}");
+                }
+            }
+        }
+
+        private static int GetBinIndex(double value, List<System.Tuple<double, double, double>> bins)
+        {
+            int binIndex = 0;
+
+            foreach (var bin in bins)
+            {
+                double lower = bin.Item1;
+                double upper = bin.Item2;
+                double step = bin.Item3;
+
+                if (value >= lower && value < upper)
+                {
+                    // Find the nearest bin value by rounding to the nearest step
+                    double roundedValue = Math.Round((value - lower) / step) * step + lower;
+
+                    // Compute the bin index
+                    return binIndex + (int)Math.Round((roundedValue - lower) / step);
+                }
+
+                // Increment the bin index by the number of bins in this range
+                binIndex += (int)Math.Round((upper - lower) / step);
+            }
+            // If out of range, return 0 if below lowest bin, or max index if above highest bin
+            return value < bins[0].Item1 ? 0 : binIndex;
+            /*
+            int binCount = 0;
+
+            foreach (var (lower, upper, binSize) in bins)
+            {
+                if (value >= lower && value < upper)
+                {
+                    int binIndex = (int)Math.Round((value - lower) / binSize);
+                    return binCount + binIndex;
+                }
+                else
+                {
+                    binCount += (int)Math.Round((upper - lower) / binSize);
+                }
+            }
+
+            return binCount; // Assigns out-of-range values to the highest bin*/
+        }
+
+        private static unsafe void FloatAsConsecUint8(byte* dst, int stride, float* array, int width, int height, int x, int y)
+        {
+            float value = array[y * width + x];
+            byte* pixel = &dst[y * stride + x * 4];
+
+            byte* bytes = (byte*)&value;
+            pixel[0] = bytes[0]; // B
+            pixel[1] = bytes[1]; // G
+            pixel[2] = bytes[2]; // R
+            pixel[3] = bytes[3]; // A (preserves float data)
+        }
+
+        public static unsafe void FloatAsSignedRGBA(byte* dst, int stride, float* array, int width, int height, int x, int y)
+        {
+            /*
+            Float     | IEEE 754 (Hex) | R  | G  | B  | A  
+            ------------------------------------------------
+            0.000000  | 0x00000000   |   0 |   0 |   0 |   0
+            0.500000  | 0x3F000000   |   0 |   0 |   0 | 126
+            1.000000  | 0x3F800000   |   0 |   0 |   0 | 127
+            2.000000  | 0x40000000   |   0 |   0 |   0 | 128
+            5.000000  | 0x40A00000   |   0 |  64 |   0 | 129
+            10.000000 | 0x41200000   |   0 |  64 |   0 | 130
+            20.000000 | 0x41A00000   |   0 |  64 |   0 | 131
+            50.000000 | 0x42480000   |   0 | 144 |   0 | 132
+            100.000000 | 0x42C80000   |   0 | 144 |   0 | 133
+            200.000000 | 0x43480000   |   0 | 144 |   0 | 134
+            500.000000 | 0x43FA0000   |   0 | 244 |   0 | 135
+            1000.000000 | 0x447A0000   |   0 | 244 |   0 | 136
+            2000.000000 | 0x44FA0000   |   0 | 244 |   0 | 137
+            5000.000000 | 0x459C4000   |   0 |  56 | 128 | 139
+            10000.000000 | 0x461C4000   |   0 |  56 | 128 | 140
+            20000.000000 | 0x469C4000   |   0 |  56 | 128 | 141
+            50000.000000 | 0x47435000   |   0 | 134 | 160 | 142
+            2.000000  | 0x3FFFFFFF   | 127 | 255 | 255 | 127
+            2.000000  | 0x40000000   |   0 |   0 |   0 | 128
+            2.000000  | 0x40000001   |   1 |   0 |   0 | 128
+            */
+            float value = array[y * width + x];
+
+            // Interpret float as 32-bit integer to extract sign, exponent, and fraction
+            uint bits = *(uint*)&value;
+
+            byte signBit = (byte)((bits >> 31) & 0x1);      // 1-bit sign (0 for +, 1 for -)
+            byte exponent = (byte)((bits >> 23) & 0xFF);    // 8-bit exponent
+            uint fraction = bits & 0x7FFFFF;                // 23-bit mantissa
+
+            // Extract mantissa bits for distribution
+            byte green = (byte)((fraction >> 15) & 0xFF);   // Most significant 8 bits of mantissa
+            byte blue = (byte)((fraction >> 7) & 0xFF);     // Next 8 bits of mantissa
+            byte red = (byte)((fraction & 0x7F) | (signBit << 7)); // Remaining 7 bits + sign in MSB
+
+            // Get pointer to pixel location
+            byte* pixel = &dst[y * stride + x * 4];
+
+            // Assign pixel values (BGRA format)
+            pixel[0] = blue;   // B (Next 8 bits of mantissa)
+            pixel[1] = green;  // G (Most significant 8 bits of mantissa)
+            pixel[2] = red;    // R (Sign bit in MSB + lowest 7 mantissa bits)
+            pixel[3] = exponent; // A (Exponent)
+        }
+
+
+        private static unsafe void FloatAsDistributedRGBA(byte* dst, int stride, float* array, int width, int height, int x, int y)
+        {
+            float value = array[y * width + x];
+
+            // Interpret float as 32-bit integer to extract sign, exponent, and fraction
+            uint bits = *(uint*)&value;
+
+            byte sign = (byte)((bits >> 31) == 0 ? 255 : 127);  // 1-bit sign (A channel)
+            byte exponent = (byte)((bits >> 23) & 0xFF);        // 8-bit exponent
+            uint fraction = bits & 0x7FFFFF;                    // 23-bit fraction
+
+            // Distribute the fraction evenly across B, G, R channels
+            byte blue = (byte)(exponent | ((fraction >> 16) & 0xFF));
+            byte green = (byte)(exponent | ((fraction >> 8) & 0xFF));
+            byte red = (byte)(exponent | (fraction & 0xFF));
+
+            // Get pointer to pixel location
+            byte* pixel = &dst[y * stride + x * 4];
+
+            // Assign pixel values (BGRA format)
+            pixel[0] = blue;   // B
+            pixel[1] = green;  // G
+            pixel[2] = red;    // R
+            pixel[3] = sign;   // A (Sign bit: 255 for positive, 127 for negative)
+        }
+
+        public static unsafe void TestFloatToRGBA()
+        {
+            float[] testValues =
+            {
+                0, 0.5f, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000,
+                2000, 5000, 10000, 20000, 50000,
+                1.9999999f, // Just before 2.0
+                2.0f, // Exactly 2.0
+                2.0000002f  // Just after 2.0
+            };
+
+            Debug.Log("Float     | IEEE 754 (Hex) | R  | G  | B  | A  ");
+            Debug.Log("------------------------------------------------");
+
+            // Allocate temporary buffer for one pixel
+            byte[] buffer = new byte[4];
+            fixed (byte* dst = buffer)
+            {
+                foreach (float value in testValues)
+                {
+                    // Convert float to raw IEEE 754 bits
+                    uint bits = *(uint*)&value;
+
+                    // Call the function (processes one value as if it's a 1x1 image)
+                    float[] array = new float[] { value };
+                    fixed (float* ptr = array)
+                    {
+                        FloatAsSignedRGBA(dst, 4, ptr, 1, 1, 0, 0); // change as needed!
+                    }
+
+                    // Extract resulting BGRA values
+                    byte blue = buffer[0];
+                    byte green = buffer[1];
+                    byte red = buffer[2];
+                    byte alpha = buffer[3];
+
+                    // Print results in a structured table
+                    Debug.Log($"{value,-9:F6} | 0x{bits:X8}   | {red,3} | {green,3} | {blue,3} | {alpha,3}");
+                }
+            }
+        }
+
+
+
+        public static unsafe void Save2dFloat32ArrayAsPNG32(string filePath, int width, int height, float* array)
+        {
+            TestFloatToRGBA();
+            using (Bitmap bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb))
+            {
+                BitmapData data = bitmap.LockBits(
+                    new Rectangle(0, 0, width, height),
+                    ImageLockMode.WriteOnly,
+                    PixelFormat.Format32bppArgb);
+
+                byte* dst = (byte*)data.Scan0;
+                int stride = data.Stride;
+
+                for (int y = 0; y < height; y++)
+                {
+                    for (int x = 0; x < width; x++)
+                    {
+                        FloatAsConsecUint8(dst, stride, array, width, height, x, y);
+                    }
+                }
+
+                bitmap.UnlockBits(data);
+
+                try
+                {
+                    bitmap.Save(filePath, ImageFormat.Png);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error saving file: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/mod/_WorldGenStateCapture/ModAssets.cs
+++ b/mod/_WorldGenStateCapture/ModAssets.cs
@@ -15,10 +15,15 @@ using System.Threading.Tasks;
 using System.Threading;
 using MapsNotIncluded_WorldParser.WorldStateData;
 using MapsNotIncluded_WorldParser;
+using Newtonsoft.Json;
+using System.Text.RegularExpressions;
+using static _WorldGenStateCapture.WorldExporter;
 
 namespace _WorldGenStateCapture
 {
-	internal class ModAssets
+
+
+    internal class ModAssets
 	{
 		//if any other mods are installed
 		public static bool ModDilution = false;
@@ -86,7 +91,7 @@ namespace _WorldGenStateCapture
             LastConnectionSuccessful = false;
         }
 
-        internal static void AccumulateSeedData()
+		internal static void AccumulateSeedData()
 		{
 
 			if (ModAssets.ModDilution)
@@ -114,12 +119,12 @@ namespace _WorldGenStateCapture
 			ClusterLayout clusterData = SettingsCache.clusterLayouts.GetClusterData(layoutQualitySetting.id);
 			SettingLevel seedQualitySetting = CustomGameSettings.Instance.GetCurrentQualitySetting(CustomGameSettingConfigs.WorldgenSeed);
 
-            if(!int.TryParse(seedQualitySetting.id, out int seed))
+			if (!int.TryParse(seedQualitySetting.id, out int seed))
 			{
 				Debug.LogError("Seed Quality Setting was not a valid integer?!?!?");
 			}
 
-            MNI_Statistics.Instance.SetMixingRunActive(CustomGameSettings.Instance.GetMixingSettingsCode() != "0");
+			MNI_Statistics.Instance.SetMixingRunActive(CustomGameSettings.Instance.GetMixingSettingsCode() != "0");
 
 
 			// DataItem.seed = seed;
@@ -187,8 +192,22 @@ namespace _WorldGenStateCapture
 			}
 			data.cluster = worldDataItem;
 
+			string world_save_path = System.IO.Path.Combine(Paths.ExportFolder, CustomGameSettings.Instance.GetSettingsCoordinate());
+			Debug.Log("Trying to save to " + world_save_path);
+            if (!Directory.Exists(world_save_path))
+            {
+                Debug.Log("Creating config path folder...");
+                Directory.CreateDirectory(world_save_path);
+                Debug.Log("Folder " + world_save_path + " initialized");
+            }
+            WorldExporter.SaveElementIdxAsPNG8(System.IO.Path.Combine(world_save_path, "elementIdx8.png"));
+            WorldExporter.SaveTemperatureAsPNG8(System.IO.Path.Combine(world_save_path, "temperature8.png"));
+            WorldExporter.SaveMassAsPNG8(System.IO.Path.Combine(world_save_path, "mass8.png"));
+            WorldExporter.SaveTemperatureAsPNG32(System.IO.Path.Combine(world_save_path, "temperature32.png"));
+            WorldExporter.SaveMassAsPNG32(System.IO.Path.Combine(world_save_path, "mass32.png"));
+            //WorldExporter.SaveGridAsJSON(Path.Combine(world_save_path, "world_data.json"));
 
-			MNI_Statistics.Instance.OnSeedGenerated();
+            MNI_Statistics.Instance.OnSeedGenerated();
 
 			Debug.Log("Serializing data...");
 			string json = Newtonsoft.Json.JsonConvert.SerializeObject(data);
@@ -417,8 +436,8 @@ namespace _WorldGenStateCapture
 				cachedRenderData = World.Instance.GetComponent<SubworldZoneRenderData>();
 			}
 
-			// Biomes: Get the original color for the biome
-			Color color = cachedRenderData.zoneColours[(int)type];
+            // Biomes: Get the original color for the biome
+            Color color = cachedRenderData.zoneColours[(int)type];
 
 			// Reset the alpha value so it can be shown nicely both in the map and the legend
 			color.a = 1f;

--- a/mod/_WorldGenStateCapture/Patches.cs
+++ b/mod/_WorldGenStateCapture/Patches.cs
@@ -246,7 +246,7 @@ namespace _WorldGenStateCapture
 
 				if (menuTimer != null)
 					menuTimer.Abort();
-				menuTimer.SetTimer(10);
+				menuTimer.SetTimer(Config.Instance.ModStartDelay);
 				menuTimer.SetAction(() =>
 				{
 					CloseDialogue();
@@ -254,7 +254,7 @@ namespace _WorldGenStateCapture
 				});
 
 				Dialog(STRINGS.AUTOPARSING.INPROGRESSDIALOG.TITLE,
-					STRINGS.AUTOPARSING.INPROGRESSDIALOG.DESC,
+					string.Format(STRINGS.AUTOPARSING.INPROGRESSDIALOG.DESC, Config.Instance.ModStartDelay),
 					STRINGS.AUTOPARSING.INPROGRESSDIALOG.STARTNOW,
 					() => { CancelAutoParsing(); InitAutoStart(__instance); },
 					NEWGAMESETTINGS.BUTTONS.CANCEL, CancelAutoParsing);

--- a/mod/_WorldGenStateCapture/Paths.cs
+++ b/mod/_WorldGenStateCapture/Paths.cs
@@ -11,6 +11,7 @@ namespace _WorldGenStateCapture
 		public static string GameFolder => Path.GetDirectoryName(UnityEngine.Application.dataPath);
 		public static string ModsFolder => Path.GetFullPath(Directory.GetParent(Directory.GetParent(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)).FullName).ToString());
 		public static string ConfigFolder => Path.Combine(ModsFolder, "config");
-		public static string WorldsFolder => Path.Combine(Paths.ConfigFolder, "OfflineWorlds");
+		public static string ExportFolder => Path.Combine(ModsFolder, "export");
+        public static string WorldsFolder => Path.Combine(Paths.ConfigFolder, "OfflineWorlds");
 	}
 }

--- a/mod/_WorldGenStateCapture/STRINGS.cs
+++ b/mod/_WorldGenStateCapture/STRINGS.cs
@@ -50,14 +50,18 @@
                 public static LocString NAME = "Allow Parsing Requested";
                 public static LocString DESC = "Fetch and parse seeds that were requested from users on the website. Disable to opt out of this.";
             }
+            public class MODSTARTDELAY {
+				public static LocString NAME = "Mod Start Delay";
+				public static LocString DESC = "Time in seconds the mod will wait before starting the world parsing.";
+			}
         }
 		public class AUTOPARSING
 		{
 			public class INPROGRESSDIALOG
 			{
 				public static LocString TITLE = "World collecting in progress";
-				public static LocString DESC = "World parsing is in progress and will start in 10 seconds.\nclick below to cancel";
-				public static LocString STARTNOW = "Skip timer";
+				public static LocString DESC = "World parsing is in progress and will start in {0} seconds.\nClick below to cancel (ALT+F4, SHIFT+CMD+W, or close the game to force stop).";
+				public static LocString STARTNOW = "Skip timer and start generating now";
 			}
 			public class MODSDETECTED
 			{

--- a/mod/_WorldGenStateCapture/WorldExporter.cs
+++ b/mod/_WorldGenStateCapture/WorldExporter.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+using static _WorldGenStateCapture.ImageSave;
+using static Rendering.BlockTileRenderer;
+
+namespace _WorldGenStateCapture
+{
+    class WorldExporter
+    {
+        public static unsafe void SaveElementIdxAsPNG8(string filePath)
+        {
+            ImageSave.Save2dUint8ArrayAsPNG(filePath, Grid.WidthInCells, Grid.HeightInCells, Grid.elementIdx);
+        }
+
+        public static unsafe void SaveTemperatureAsPNG8(string filePath)
+        {
+            List<System.Tuple<double, double, double>> bins = new List<System.Tuple<double, double, double>>
+            {
+                Tuple.Create(-273.5, -272.5, 1.0),
+                Tuple.Create(-272.5, -100.5, 20.0),
+                Tuple.Create(-100.5, -20.5, 5.0),
+                Tuple.Create(-20.5, 10.5, 2.0),
+                Tuple.Create(10.5, 40.5, 1.0),
+                Tuple.Create(40.5, 120.5, 2.0),
+                Tuple.Create(120.5, 200.5, 5.0),
+                Tuple.Create(200.5, 1400.5, 20.0),
+                Tuple.Create(1400.5, 2000.5, 10.0)
+            };
+
+            ImageSave.Save2dFloat32ArrayAsPNG8(filePath, Grid.WidthInCells, Grid.HeightInCells, Grid.temperature, bins, -273.15);
+        }
+
+        public static unsafe void SaveTemperatureAsPNG32(string filePath)
+        {
+            ImageSave.Save2dFloat32ArrayAsPNG32(filePath, Grid.WidthInCells, Grid.HeightInCells, Grid.temperature);
+        }
+
+        public static unsafe void SaveMassAsPNG8(string filePath)
+        {
+            List<System.Tuple<double, double, double>> bins = new List<System.Tuple<double, double, double>>
+            {
+                Tuple.Create(-0.05, 5.05, 0.1),
+                Tuple.Create(5.05, 25.5, 1.0),
+                Tuple.Create(25.5, 105.5, 10.0),
+                Tuple.Create(105.5, 2005.5, 20.0),
+                Tuple.Create(2005.5, 20005.5, 100.0)
+            };
+            ImageSave.Save2dFloat32ArrayAsPNG8(filePath, Grid.WidthInCells, Grid.HeightInCells, Grid.mass, bins, 0);
+        }
+
+        public static unsafe void SaveMassAsPNG32(string filePath)
+        {
+            ImageSave.Save2dFloat32ArrayAsPNG32(filePath, Grid.WidthInCells, Grid.HeightInCells, Grid.mass);
+        }
+
+        public static void SaveGridAsJSON(string filePath)
+        {
+            string json = SerializeGridData(Grid.CellCount);
+            File.WriteAllText(filePath, json);
+        }
+
+        public class GridData
+        {
+            public ushort ElementIdx { get; set; }
+            public float Temperature { get; set; }
+            public float Mass { get; set; }
+        }
+
+        public class ElementData
+        {
+            public ushort idx { get; set; }
+            public Tag tag { get; set; }
+            public SimHashes id { get; set; }
+            public string name { get; set; }
+        }
+
+
+        public static unsafe string SerializeGridData(int gridSize)
+        {
+            List<GridData> gridDataList = new List<GridData>(gridSize);
+            HashSet<ushort> uniqueElementIdx = new HashSet<ushort>();
+
+            for (int i = 0; i < gridSize; i++)
+            {
+                ushort elementIndex = Grid.elementIdx[i];
+                uniqueElementIdx.Add(elementIndex);
+
+                gridDataList.Add(new GridData
+                {
+                    ElementIdx = elementIndex,
+                    Temperature = Grid.temperature[i],
+                    Mass = Grid.mass[i]
+                });
+            }
+
+            // Serialize Grid Data
+            string gridDataJson = JsonConvert.SerializeObject(gridDataList, Formatting.Indented);
+
+            // Generate dictionary of unique ElementIdx found in the parsed data
+            Dictionary<ushort, Element> uniqueElementsDict = new Dictionary<ushort, Element>();
+
+            foreach (ushort idx in uniqueElementIdx)
+            {
+                if (ElementLoader.elementTable.TryGetValue(idx, out Element element))
+                {
+                    uniqueElementsDict[idx] = element;
+                }
+            }
+
+            string uniqueElementsJson = JsonConvert.SerializeObject(uniqueElementsDict
+                .ToDictionary(kv => kv.Key, kv => new ElementData
+                {
+                    idx = kv.Value.idx,
+                    tag = kv.Value.tag,
+                    id = kv.Value.id,
+                    name = kv.Value.name
+                }), Formatting.Indented);
+
+            // Serialize ALL Elements from ElementLoader
+            string allElementsJson = JsonConvert.SerializeObject(ElementLoader.elements
+                .Select(e => new ElementData
+                {
+                    idx = e.idx,
+                    tag = e.tag,
+                    id = e.id,
+                    name = e.name
+                }), Formatting.Indented);
+
+            return $"{{ \"gridData\": {gridDataJson}, \"uniqueElements\": {uniqueElementsJson}, \"allElements\": {allElementsJson} }}";
+        }
+    }
+}


### PR DESCRIPTION
Add a configurable mod start delay so that it can be changed from the default 10 seconds. This allows decreasing it to 5 seconds or increasing it up to 100 seconds of delay, with a minimum to prevent soft-locking (but configurable in JSON directly to entirely skip the delay for power users). Both of these limits are arbitrary. I also added some clarifications in the UI: that the "skip timer" button is not the "Click below to cancel" button; and the key combinations to quit the game even after the mod starts.

I built the mod and tested it to make sure it works in the game, and everything works properly.